### PR TITLE
Show a better error message when required imports fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ All notable changes to the pathfinder NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
+Added
+=====
+- Added log error message when networkx package isn't installed.
 
 [2.2.1] - 2019-03-15
 ********************

--- a/graph.py
+++ b/graph.py
@@ -1,7 +1,13 @@
 """Module Graph of kytos/pathfinder Kytos Network Application."""
 
-import networkx as nx
-from networkx.exception import NetworkXNoPath, NodeNotFound
+from kytos.core import log
+
+try:
+    import networkx as nx
+    from networkx.exception import NodeNotFound, NetworkXNoPath
+except ImportError:
+    PACKAGE = 'networkx>=2.2'
+    log.error(f"Package {PACKAGE} not found. Please 'pip install {PACKAGE}'")
 
 
 class KytosGraph:


### PR DESCRIPTION
@beraldoleal @hdiogenes, sometimes when I start over my dev environment from scratch I usually have to keep reinstalling other pip dependencies since the NApp package at the moment is not capable of bootstraping the other/third party dependencies like networkx. 

I figured it would be nice to have a bootstrap mechanism in place. With this PR it auto bootstrap if there's an ImportError:

```
❯ pip list | grep networkx
networkx                 2.2
```

```
❯ pip uninstall networkx -y
Uninstalling networkx-2.2:
  Successfully uninstalled networkx-2.2

```

```
~/repos/kytos/.direnv/python-3.6.6/var/lib/kytos/napps/.installed/kytos/pathfinder autopip_networkx
❯ kytosd -f -E
2019-01-13 19:54:35,705 - INFO [kytos.core.logs] (MainThread) Logging config file "/home/viniarck/repos/kytos/.direnv/python-3.6.6/etc/kytos/logging.ini" loaded successfully.
...
2019-01-13 19:54:35,876 - INFO [controller] (MainThread) Loading NApp kytos/pathfinder
2019-01-13 19:54:35,877 - INFO [root] (mef_eline) Running NApp: <Main(mef_eline, started 140484189910784)>
Collecting networkx>=2.2
Requirement already satisfied: decorator>=4.3.0 in /home/viniarck/repos/kytos/.direnv/python-3.6.6/lib/python3.6/site-packages (from networkx>=2.2) (4.3.0)
Installing collected packages: networkx
Successfully installed networkx-2.2
2019-01-13 19:54:38,034 - INFO [api_server] (MainThread) Started /api/kytos/pathfinder/v2/ - POST
```

What do you think?