### PR TITLE
Merge pull request #38 from cmagnobarbosa/fix_coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Overview
 ########
 
+|License| |Build| |Coverage| |Quality|
+
 .. attention::
 
     THIS NAPP IS STILL EXPERIMENTAL AND IT'S EVENTS, METHODS AND STRUCTURES MAY
@@ -60,3 +62,17 @@ Rest API
 You can find a list of the available endpoints and example input/output in the
 'REST API' tab in this NApp's webpage in the `Kytos NApps Server
 <https://napps.kytos.io/kytos/pathfinder>`_.
+
+.. TAGs
+
+.. |License| image:: https://img.shields.io/github/license/kytos/kytos.svg
+   :target: https://github.com/kytos/ /blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos/pathfinder/badges/build.png?b=master
+  :alt: Build status
+  :target: https://scrutinizer-ci.com/g/kytos/pathfinder/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos/pathfinder/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos/pathfinder/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos/pathfinder/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos/pathfinder/?branch=master

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 astroid==2.2.5            # via pylint
 click==7.0                # via pip-tools
-coverage==4.5.3
+coverage==5.0.3
 docopt==0.6.2             # via yala
 filelock==3.0.10          # via tox
 isort==4.3.15             # via pylint, yala


### PR DESCRIPTION
The coverage version was creating an error when running Scrutinizer.
This commit changes coverage version from 4.5.3 to 5.0.3 and add some badges in README.