### PR TITLE
Create tags decorator to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = *tests*,.tox/*,setup.py
+omit = .eggs/*,.tox/*,*tests*,setup.py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,6 +21,7 @@ py==1.8.0                 # via tox
 pycodestyle==2.5.0        # via yala
 pydocstyle==3.0.0         # via yala
 pylint==2.3.1             # via yala
+pytest==5.4.1             # via pytest
 six==1.12.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 toml==0.10.0              # via tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,9 @@ known_first_party = kytos.napps,tests
 known_third_party = pyof,kytos
 # Ignoring tests because is adding napps path
 skip=tests
+
+[tool:pytest]
+markers =
+    small: marks tests as small
+    medium: marks tests as medium
+    large: marks tests as large

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from abc import abstractmethod
 from pathlib import Path
-from subprocess import call, check_call
+from subprocess import CalledProcessError, call, check_call
 
 from setuptools import Command, setup
 from setuptools.command.develop import develop
@@ -19,10 +19,7 @@ if 'bdist_wheel' in sys.argv:
     raise RuntimeError("This setup.py does not support wheels")
 
 # Paths setup with virtualenv detection
-if 'VIRTUAL_ENV' in os.environ:
-    BASE_ENV = Path(os.environ['VIRTUAL_ENV'])
-else:
-    BASE_ENV = Path('/')
+BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'pathfinder'
 NAPP_VERSION = '2.2.2'
@@ -65,6 +62,39 @@ class SimpleCommand(Command):
         """Post-process options."""
 
 
+# pylint: disable=attribute-defined-outside-init, abstract-method
+class TestCommand(Command):
+    """Test tags decorators."""
+
+    user_options = [
+        ('size=', None, 'Specify the size of tests to be executed.'),
+        ('type=', None, 'Specify the type of tests to be executed.'),
+    ]
+
+    sizes = ('small', 'medium', 'large', 'all')
+    types = ('unit', 'integration', 'e2e')
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        return '--size %s --type %s' % (self.size, self.type)
+
+    def initialize_options(self):
+        """Set default size and type args."""
+        self.size = 'all'
+        self.type = 'unit'
+
+    def finalize_options(self):
+        """Post-process."""
+        try:
+            assert self.size in self.sizes, ('ERROR: Invalid size:'
+                                             f':{self.size}')
+            assert self.type in self.types, ('ERROR: Invalid type:'
+                                             f':{self.type}')
+        except AssertionError as exc:
+            print(exc)
+            sys.exit(-1)
+
+
 class Cleaner(SimpleCommand):
     """Custom clean command to tidy up the project root."""
 
@@ -77,17 +107,41 @@ class Cleaner(SimpleCommand):
         call('make -C docs/ clean', shell=True)
 
 
-class TestCoverage(SimpleCommand):
-    """Display test coverage."""
+class Test(TestCommand):
+    """Run all tests."""
 
-    description = 'run unit tests and display code coverage'
+    description = 'run tests and display results'
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        markers = self.size
+        if markers == "small":
+            markers = 'not medium and not large'
+        size_args = "" if self.size == "all" else "-m '%s'" % markers
+        return '--addopts="tests/%s %s"' % (self.type, size_args)
 
     def run(self):
-        """Run unittest quietly and display coverage report."""
-        # Temporarily only unit tests is enabled
-        cmd = 'coverage3 run -m unittest discover -s tests/unit \
-               && coverage3 report'
-        call(cmd, shell=True)
+        """Run tests."""
+        cmd = 'python setup.py pytest %s' % self.get_args()
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
+
+
+class TestCoverage(Test):
+    """Display test coverage."""
+
+    description = 'run tests and display code coverage'
+
+    def run(self):
+        """Run tests quietly and display coverage report."""
+        cmd = 'coverage3 run setup.py pytest %s' % self.get_args()
+        cmd += '&& coverage3 report'
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
 
 
 class Linter(SimpleCommand):
@@ -107,16 +161,16 @@ class Linter(SimpleCommand):
             exit(-1)
 
 
-class CITest(SimpleCommand):
+class CITest(TestCommand):
     """Run all CI tests."""
 
     description = 'run all CI tests: unit and doc tests, linter'
 
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
-        cmds = ['python3.6 setup.py ' + cmd
-                for cmd in ('coverage', 'lint')]
-        cmd = ' && '.join(cmds)
+        coverage_cmd = 'python3.6 setup.py coverage %s' % self.get_args()
+        lint_cmd = 'python3.6 setup.py lint'
+        cmd = '%s && %s' % (coverage_cmd, lint_cmd)
         check_call(cmd, shell=True)
 
 
@@ -228,6 +282,8 @@ setup(name=f'kytos_{NAPP_NAME}',
           'kytos>=2017.2b1',
           'networkx'
       ],
+      setup_requires=['pytest-runner'],
+      tests_require=['pytest'],
       extras_require={
           'dev': [
               'coverage',
@@ -244,6 +300,7 @@ setup(name=f'kytos_{NAPP_NAME}',
           'install': InstallMode,
           'lint': Linter,
           'egg_info': EggInfo,
+          'test': Test,
       },
       zip_safe=False,
       classifiers=[

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""kytos/pathfinder unit tests."""

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -1,11 +1,12 @@
 """Test Graph methods."""
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 from napps.kytos.pathfinder.graph import KytosGraph
 from tests.helpers import get_topology_mock
 
 
+# pylint: disable=arguments-differ, protected-access
 class TestGraph(TestCase):
     """Tests for the Main class."""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,6 +1,6 @@
 """Test Main methods."""
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from kytos.core.events import KytosEvent
 from kytos.lib.helpers import get_controller_mock, get_test_client
@@ -17,8 +17,7 @@ class TestMain(TestCase):
         """Execute steps before each tests."""
         self.napp = Main(get_controller_mock())
 
-    @patch('napps.kytos.pathfinder.graph.KytosGraph.update_topology')
-    def test_update_topology_success_case(self, mock_update_topology):
+    def test_update_topology_success_case(self):
         """Test update topology method to success case."""
         topology = get_topology_mock()
         event = KytosEvent(name='kytos.topology.updated',
@@ -27,8 +26,7 @@ class TestMain(TestCase):
 
         self.assertEqual(self.napp._topology, topology)
 
-    @patch('napps.kytos.pathfinder.graph.KytosGraph.update_topology')
-    def test_update_topology_failure_case(self, mock_update_topology):
+    def test_update_topology_failure_case(self):
         """Test update topology method to failure case."""
         event = KytosEvent(name='kytos.topology.updated')
         self.napp.update_topology(event)


### PR DESCRIPTION
Today, all the tests are executed without distinction. This commit creates a tag to divide tests in type (unit, integration, e2e) and in size (small, medium, large, all). "Unit" and "all" are the standard parameters.

To set tags to a test function:

```python
import pytest

@pytest.mark.medium
def test_function():
...
```
To run the tests:

```shell
 python setup.py ci --size=all --type=unit
```

The _'test'_ parameter uses the standard arguments and each function starts with small size argument by default.

By default, Pytest only runs tests inside folder defined in type argument (It isn't necessary to use the type argument in the tag decorator).

Directory hierarchy:

```
/tests/
... e2e/
... integration/
... unit/
```

Related 
https://github.com/kytos/kytos/issues/1041