### PR TITLE
Add Best Constrained Path Menu

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,9 +13,6 @@ Added
 
 Changed
 =======
-- Improved documentation about napp dependencies.
-- Changed tests structure to separate unit and integration tests.
-- Updated Pathfinder UI with a best constrained flexible paths search menu.
 
 Deprecated
 ==========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 =======
 - Improved documentation about napp dependencies.
 - Changed tests structure to separate unit and integration tests.
+- Updated Pathfinder UI with a best constrained flexible paths search menu.
 
 Deprecated
 ==========

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -113,8 +113,7 @@ module.exports = {
         data: JSON.stringify({"source": self.source,
                "destination": self.destination,
                "metrics": metrics,
-               "flexible": self.flexible,
-               "checks": self.checkedList
+               "flexible": self.flexible
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v3",

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -3,141 +3,86 @@
     <div style="overflow-y: auto; height:550px;">
       <k-accordion>
         <k-accordion-item title="Best Path">
-          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-            :value.sync="source"></k-dropdown>
-          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-            :value.sync ="destination"></k-dropdown>
+         <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+          :value.sync="source"></k-dropdown>
+         <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+          :value.sync ="destination"></k-dropdown>
          <k-select icon="link" title="Desired links:" :options="get_links"
           :value.sync ="desired_links"></k-select>
          <k-select icon="link" title="Undesired links:" :options="get_links"
           :value.sync ="undesired_links"></k-select>
-          <k-button icon="search" title="Search" :on_click="get_paths">
-          </k-button>
+         <k-button icon="search" title="Search" :on_click="get_paths">
+         </k-button>
         </k-accordion-item>
 
-        <k-accordion-item title="Best Constrained Path with Flexible Metrics">
-          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-            :value.sync="v4_source"></k-dropdown>
-          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-            :value.sync ="v4_destination"></k-dropdown>
+        <k-accordion-item title="Best Constrained Path">
+           <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+            :value.sync="source_constrained"></k-dropdown>
+           <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+            :value.sync ="destination_constrained"></k-dropdown>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'bandwidth'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['bandwidth']" 
-              :value.sync="v4_is_flexible.bandwidth"></k-dropdown>
+               :value.sync="is_flexible.bandwidth"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {v4_metrics.bandwidth = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {metrics.bandwidth = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'reliability'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['reliability']" 
-              :value.sync="v4_is_flexible.reliability"></k-dropdown>
+              :value.sync="is_flexible.reliability"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {v4_metrics.reliability = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {metrics.reliability = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'delay'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['delay']" 
-              :value.sync="v4_is_flexible.delay"></k-dropdown>
+              :value.sync="is_flexible.delay"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {v4_metrics.delay = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {metrics.delay = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'utilization'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['utilization']" 
-              :value.sync="v4_is_flexible.utilization"></k-dropdown>
+              :value.sync="is_flexible.utilization"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {v4_metrics.utilization = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {metrics.utilization = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'priority'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['priority']" 
-              :value.sync="v4_is_flexible.priority"></k-dropdown>
+              :value.sync="is_flexible.priority"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {v4_metrics.priority = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {metrics.priority = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "v4_checked_list" :value = "'ownership'"></k-checkbox>
+              <k-checkbox :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['ownership']" 
-              :value.sync="v4_is_flexible.ownership"></k-dropdown>
+              :value.sync="is_flexible.ownership"></k-dropdown>
             </div>
           </div>
-          <k-input :value.sync="v4_metrics.ownership"></k-input>
+          <k-input :value.sync="metrics.ownership"></k-input>
           <k-slider :max = 6
-          :action="function (val) {depth = parseInt(val)}"></k-slider>
-          <k-button icon="search" title="Search" :on_click="get_constrained_paths_v4">
-          </k-button>
-        </k-accordion-item>
-  
-        <k-accordion-item title="Best Constrained Path">
-          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-            :value.sync="v3_source"></k-dropdown>
-          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-            :value.sync ="v3_destination"></k-dropdown>
-          <div style="width: 100%; overflow: hidden;">
-              <div style="width:50%; float: left;"> 
-                <k-slider icon="adjust"
-                :action="function (val) {v3_metrics.bandwidth = parseInt(val)}"></k-slider>
-              </div>
-              <div style="margin-left: 1em;"> 
-                <k-checkbox title="Bandwidth" 
-                :model.sync = "v3_checked_list" :value = "'bandwidth'"></k-checkbox>
-              </div>
-              <div style="width:50%; float: left;"> 
-                <k-slider icon="adjust"
-                :action="function (val) {v3_metrics.reliability = parseInt(val)}"></k-slider>
-              </div>
-              <div style="margin-left: 1em;"> 
-                <k-checkbox title="Reliability"
-                :model.sync = "v3_checked_list" :value = "'reliability'"></k-checkbox>
-              </div>
-              <div style="width:50%; float: left;"> 
-                <k-slider icon="adjust"
-                :action="function (val) {v3_metrics.delay = parseInt(val)}"></k-slider>
-              </div>
-              <div style="margin-left: 1em;"> 
-                <k-checkbox title="Delay"
-                :model.sync = "v3_checked_list" :value = "'delay'"></k-checkbox>
-              </div>
-              <div style="width:50%; float: left;"> 
-                <k-slider icon="adjust"
-                :action="function (val) {v3_metrics.utilization = parseInt(val)}"></k-slider>
-              </div>
-              <div style="margin-left: 1em;"> 
-                <k-checkbox title="Utilization"
-                :model.sync = "v3_checked_list" :value = "'utilization'"></k-checkbox>
-              </div>
-              <div style="width:50%; float: left;"> 
-                <k-slider icon="adjust"
-                :action="function (val) {v3_metrics.priority = parseInt(val)}"></k-slider>
-              </div>
-              <div style="margin-left: 1em;"> 
-                <k-checkbox title="Priority"
-                :model.sync = "v3_checked_list" :value = "'priority'"></k-checkbox>
-              </div>
-          </div>
-          <k-checkbox icon="adjust" title="Ownership:"
-          :model.sync = "v3_checked_list" :value = "'ownership'"></k-checkbox>
-          <k-input 
-          :value.sync="v3_metrics.ownership"></k-input>
-          <k-button icon="search" title="Search" :on_click="get_constrained_paths_v3">
+          :action="function (val) {maximum_misses = parseInt(val)}"></k-slider>
+          <k-button icon="search" title="Search" :on_click="get_constrained_paths">
           </k-button>
         </k-accordion-item>
       <k-accordion>
@@ -173,44 +118,15 @@ module.exports = {
       });
 
     },
-    get_constrained_paths_v3 (){
-      var self = this
-      var metrics = {}
-      for(var checked of self.v3_checked_list)
-      {
-        metrics[checked] = self.v3_metrics[checked]
-      }
-
-      $.ajax({
-        async: true,
-        dataType: "json",
-        type: "POST",
-        contentType: "application/json",
-        data: JSON.stringify({"source": self.v3_source,
-               "destination": self.v3_destination,
-               "base_metrics": metrics
-               }),
-
-        url: this.$kytos_server_api + "kytos/pathfinder/v3",
-        success: function(data) {
-            if (data[0] !== undefined){
-                self.paths = data[0]['paths'][0];
-            } else {
-                self.paths = []
-            }
-          self.show();
-        }
-      });
-    },
-    get_constrained_paths_v4(){
+    get_constrained_paths(){
       var self = this
       var base_metrics = {}
       var flexible_metrics = {}
-      for(var checked of self.v4_checked_list) {
-        if (self.v4_is_flexible[checked]) {
-          flexible_metrics[checked] = self.v4_metrics[checked]
+      for(var checked of self.checked_list) {
+        if (self.is_flexible[checked]) {
+          flexible_metrics[checked] = self.metrics[checked]
         } else {
-          base_metrics[checked] = self.v4_metrics[checked]
+          base_metrics[checked] = self.metrics[checked]
         }
       }
       
@@ -219,14 +135,14 @@ module.exports = {
         dataType: "json",
         type: "POST",
         contentType: "application/json",
-        data: JSON.stringify({"source": self.v4_source,
-               "destination": self.v4_destination,
+        data: JSON.stringify({"source": self.source_constrained,
+               "destination": self.destination_constrained,
                "base_metrics": base_metrics,
                "flexible_metrics": flexible_metrics,
-               "depth": self.depth
+               "maximum_misses": self.maximum_misses
                }),
 
-        url: this.$kytos_server_api + "kytos/pathfinder/v4",
+        url: this.$kytos_server_api + "kytos/pathfinder/v2/best-constrained-paths",
         success: function(data) {
             if (data[0] !== undefined){
                 self.paths = data[0]['paths'][0];
@@ -335,10 +251,10 @@ module.exports = {
       destination: "",
       desired_links: [],
       undesired_links: [],
-      v3_source: "",
-      v3_destination: "",
-      v3_checked_list: [],
-      v3_metrics:{
+      source_constrained: "",
+      destination_constrained: "",
+      checked_list: [],
+      metrics:{
         bandwidth: 0,
         reliability: 0,
         delay: 0,
@@ -346,18 +262,7 @@ module.exports = {
         priority: 0,
         ownership: ""
       },
-      v4_source: "",
-      v4_destination: "",
-      v4_checked_list: [],
-      v4_metrics:{
-        bandwidth: 0,
-        reliability: 0,
-        delay: 0,
-        utilization: 0,
-        priority: 0,
-        ownership: ""
-      },
-      v4_is_flexible:{
+      is_flexible:{
         bandwidth: false,
         reliability: false,
         delay: false,
@@ -365,7 +270,7 @@ module.exports = {
         priority: false,
         ownership: false
       },
-      depth: 0
+      maximum_misses: 0
     }
   }
 }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -71,7 +71,7 @@
           :value.sync="metrics.ownership"></k-input>
   
           <k-slider :max = 6
-          :action="function (val) {flexible = parseInt(val)}"></k-slider>
+          :action="function (val) {depth = parseInt(val)}"></k-slider>
   
           <k-button icon="search" title="Search" :on_click="get_constrained_paths">
           </k-button>
@@ -124,8 +124,8 @@ module.exports = {
         contentType: "application/json",
         data: JSON.stringify({"source": self.source,
                "destination": self.destination,
-               "metrics": metrics,
-               "flexible": self.flexible
+               "base_metrics": metrics,
+               "depth": self.depth
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v3",
@@ -210,7 +210,7 @@ module.exports = {
         priority: 0,
         ownership: ""
       },
-      flexible: 0
+      depth: 0
     }
   }
 }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -17,10 +17,9 @@
 
         <k-accordion-item title="Best Constrained Path with Flexible Metrics">
           <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-            :value.sync="source"></k-dropdown>
+            :value.sync="v4_source"></k-dropdown>
           <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-            :value.sync ="destination"></k-dropdown>
-
+            :value.sync ="v4_destination"></k-dropdown>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
               <k-checkbox :model.sync = "v4_checked_list" :value = "'bandwidth'"></k-checkbox>
@@ -81,20 +80,17 @@
             </div>
           </div>
           <k-input :value.sync="v4_metrics.ownership"></k-input>
-
           <k-slider :max = 6
           :action="function (val) {depth = parseInt(val)}"></k-slider>
-  
           <k-button icon="search" title="Search" :on_click="get_constrained_paths_v4">
           </k-button>
         </k-accordion-item>
   
         <k-accordion-item title="Best Constrained Path">
           <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-            :value.sync="source"></k-dropdown>
+            :value.sync="v3_source"></k-dropdown>
           <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-            :value.sync ="destination"></k-dropdown>
-  
+            :value.sync ="v3_destination"></k-dropdown>
           <div style="width: 100%; overflow: hidden;">
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
@@ -137,13 +133,10 @@
                 :model.sync = "v3_checked_list" :value = "'priority'"></k-checkbox>
               </div>
           </div>
-  
           <k-checkbox icon="adjust" title="Ownership:"
           :model.sync = "v3_checked_list" :value = "'ownership'"></k-checkbox>
-  
           <k-input 
           :value.sync="v3_metrics.ownership"></k-input>
-  
           <k-button icon="search" title="Search" :on_click="get_constrained_paths_v3">
           </k-button>
         </k-accordion-item>
@@ -193,8 +186,8 @@ module.exports = {
         dataType: "json",
         type: "POST",
         contentType: "application/json",
-        data: JSON.stringify({"source": self.source,
-               "destination": self.destination,
+        data: JSON.stringify({"source": self.v3_source,
+               "destination": self.v3_destination,
                "base_metrics": metrics
                }),
 
@@ -214,7 +207,7 @@ module.exports = {
       var base_metrics = {}
       var flexible_metrics = {}
       for(var checked of self.v4_checked_list) {
-        if (self.v4_is_flexible[checked] == 'true') {
+        if (self.v4_is_flexible[checked]) {
           flexible_metrics[checked] = self.v4_metrics[checked]
         } else {
           base_metrics[checked] = self.v4_metrics[checked]
@@ -226,12 +219,11 @@ module.exports = {
         dataType: "json",
         type: "POST",
         contentType: "application/json",
-        data: JSON.stringify({"source": self.source,
-               "destination": self.destination,
+        data: JSON.stringify({"source": self.v4_source,
+               "destination": self.v4_destination,
                "base_metrics": base_metrics,
                "flexible_metrics": flexible_metrics,
-               "depth": self.depth,
-               "isFlexible": self.v4_is_flexible
+               "depth": self.depth
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v4",
@@ -283,23 +275,23 @@ module.exports = {
       var priority_options = []
       var ownership_options = []
 
-      bandwidth_options.push({value: 'false', description: 'Bandwidth', selected: 'true'});
-      bandwidth_options.push({value: 'true', description: 'Bandwidth (Flexible)'});
+      bandwidth_options.push({value: false, description: 'Bandwidth', selected: true});
+      bandwidth_options.push({value: true, description: 'Bandwidth (Flexible)'});
       
-      reliability_options.push({value: 'false', description: 'Reliability', selected: 'true'});
-      reliability_options.push({value: 'true', description: 'Reliability (Flexible)'});
+      reliability_options.push({value: false, description: 'Reliability', selected: true});
+      reliability_options.push({value: true, description: 'Reliability (Flexible)'});
 
-      delay_options.push({value: 'false', description: 'Delay', selected: 'true'});
-      delay_options.push({value: 'true', description: 'Delay (Flexible)'});
+      delay_options.push({value: false, description: 'Delay', selected: true});
+      delay_options.push({value: true, description: 'Delay (Flexible)'});
 
-      utilization_options.push({value: 'false', description: 'Utilization', selected: 'true'});
-      utilization_options.push({value: 'true', description: 'Utilization (Flexible)'});
+      utilization_options.push({value: false, description: 'Utilization', selected: true});
+      utilization_options.push({value: true, description: 'Utilization (Flexible)'});
 
-      priority_options.push({value: 'false', description: 'Priority', selected: 'true'});
-      priority_options.push({value: 'true', description: 'Priority (Flexible)'});
+      priority_options.push({value: false, description: 'Priority', selected: true});
+      priority_options.push({value: true, description: 'Priority (Flexible)'});
 
-      ownership_options.push({value: 'false', description: 'Ownership', selected: 'true'});
-      ownership_options.push({value: 'true', description: 'Ownership (Flexible)'});
+      ownership_options.push({value: false, description: 'Ownership', selected: true});
+      ownership_options.push({value: true, description: 'Ownership (Flexible)'});
 
       metric_options["bandwidth"] = bandwidth_options
       metric_options["reliability"] = reliability_options
@@ -343,6 +335,8 @@ module.exports = {
       destination: "",
       desired_links: [],
       undesired_links: [],
+      v3_source: "",
+      v3_destination: "",
       v3_checked_list: [],
       v3_metrics:{
         bandwidth: 0,
@@ -352,6 +346,8 @@ module.exports = {
         priority: 0,
         ownership: ""
       },
+      v4_source: "",
+      v4_destination: "",
       v4_checked_list: [],
       v4_metrics:{
         bandwidth: 0,

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -373,3 +373,9 @@ module.exports = {
   }
 }
 </script>
+
+<style type="text/css">
+body{
+    overflow-y:hidden;
+}
+</style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -99,8 +99,8 @@ module.exports = {
     get_constrained_paths (){
       var self = this
       var metrics = {}
-      var checked
-      for(checked of self.checkedList)
+
+      for(var checked of self.checkedList)
       {
         metrics[checked] = self.metrics[checked]
       }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,70 +1,83 @@
 <template>
   <k-toolbar-item icon="compass" tooltip="Napp Pathfinder">
-    <k-accordion>
-      <k-accordion-item title="Best Path">
-        <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-          :value.sync="source"></k-dropdown>
-        <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-          :value.sync ="destination"></k-dropdown>
-       <k-select icon="link" title="Desired links:" :options="get_links"
-        :value.sync ="desired_links"></k-select>
-       <k-select icon="link" title="Undesired links:" :options="get_links"
-        :value.sync ="undesired_links"></k-select>
-        <k-button icon="search" title="Search" :on_click="get_paths">
-        </k-button>
-
-      </k-accordion-item>
-      <k-accordion-item title="Best Constrained Path">
-        <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
-          :value.sync="source"></k-dropdown>
-        <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
-          :value.sync ="destination"></k-dropdown>
-
-        <k-checkbox icon="circle-o" title="Bandwidth:"
-        :model.sync = "checkedList" :value = "'bandwidth'"></k-checkbox>
-
-        <k-slider 
-        :action="function (val) {metrics.bandwidth = parseInt(val)}"></k-slider>
-
-        <k-checkbox icon="circle-o" title="Reliability:"
-        :model.sync = "checkedList" :value = "'reliability'"></k-checkbox>
-
-        <k-slider
-        :action="function (val) {metrics.reliability = parseInt(val)}"></k-slider>
-
-        <k-checkbox icon="circle-o" title="Delay:"
-        :model.sync = "checkedList" :value = "'delay'"></k-checkbox>
-
-        <k-slider 
-        :action="function (val) {metrics.delay = parseInt(val)}"></k-slider>
-
-        <k-checkbox icon="circle-o" title="Utilization:"
-        :model.sync = "checkedList" :value = "'utilization'"></k-checkbox>
-
-        <k-slider 
-        :action="function (val) {metrics.utilization = parseInt(val)}"></k-slider>
-
-        <k-checkbox icon="circle-o" title="Priority:"
-        :model.sync = "checkedList" :value = "'priority'"></k-checkbox>
-
-        <k-slider
-        :action="function (val) {metrics.priority = parseInt(val)}"></k-slider>
-
-        <k-checkbox icon="circle-o" title="Ownership:"
-        :model.sync = "checkedList" :value = "'ownership'"></k-checkbox>
-
-        <k-input 
-        :value.sync="metrics.ownership"></k-input>
-
-        <k-slider :max = 6
-        :action="function (val) {flexible = parseInt(val)}"></k-slider>
-
-        <k-button icon="search" title="Search" :on_click="get_constrained_paths">
-        </k-button>
-
-      </k-accordion-item>
-
-    <k-accordion>
+    <div style="overflow-y: auto; height:550px;">
+      <k-accordion>
+        <k-accordion-item title="Best Path">
+          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+            :value.sync="source"></k-dropdown>
+          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+            :value.sync ="destination"></k-dropdown>
+         <k-select icon="link" title="Desired links:" :options="get_links"
+          :value.sync ="desired_links"></k-select>
+         <k-select icon="link" title="Undesired links:" :options="get_links"
+          :value.sync ="undesired_links"></k-select>
+          <k-button icon="search" title="Search" :on_click="get_paths">
+          </k-button>
+        </k-accordion-item>
+  
+        <k-accordion-item title="Best Constrained Path">
+          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+            :value.sync="source"></k-dropdown>
+          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+            :value.sync ="destination"></k-dropdown>
+  
+          <div style="width: 100%; overflow: hidden;">
+              <div style="width:50%; float: left;"> 
+                <k-slider icon="adjust"
+                :action="function (val) {metrics.bandwidth = parseInt(val)}"></k-slider>
+              </div>
+              <div style="margin-left: 1em;"> 
+                <k-checkbox title="Bandwidth" 
+                :model.sync = "checkedList" :value = "'bandwidth'"></k-checkbox>
+              </div>
+              <div style="width:50%; float: left;"> 
+                <k-slider icon="adjust"
+                :action="function (val) {metrics.reliability = parseInt(val)}"></k-slider>
+              </div>
+              <div style="margin-left: 1em;"> 
+                <k-checkbox title="Reliability"
+                :model.sync = "checkedList" :value = "'reliability'"></k-checkbox>
+              </div>
+              <div style="width:50%; float: left;"> 
+                <k-slider icon="adjust"
+                :action="function (val) {metrics.delay = parseInt(val)}"></k-slider>
+              </div>
+              <div style="margin-left: 1em;"> 
+                <k-checkbox title="Delay"
+                :model.sync = "checkedList" :value = "'delay'"></k-checkbox>
+              </div>
+              <div style="width:50%; float: left;"> 
+                <k-slider icon="adjust"
+                :action="function (val) {metrics.utilization = parseInt(val)}"></k-slider>
+              </div>
+              <div style="margin-left: 1em;"> 
+                <k-checkbox title="Utilization"
+                :model.sync = "checkedList" :value = "'utilization'"></k-checkbox>
+              </div>
+              <div style="width:50%; float: left;"> 
+                <k-slider icon="adjust"
+                :action="function (val) {metrics.priority = parseInt(val)}"></k-slider>
+              </div>
+              <div style="margin-left: 1em;"> 
+                <k-checkbox title="Priority"
+                :model.sync = "checkedList" :value = "'priority'"></k-checkbox>
+              </div>
+          </div>
+  
+          <k-checkbox icon="adjust" title="Ownership:"
+          :model.sync = "checkedList" :value = "'ownership'"></k-checkbox>
+  
+          <k-input 
+          :value.sync="metrics.ownership"></k-input>
+  
+          <k-slider :max = 6
+          :action="function (val) {flexible = parseInt(val)}"></k-slider>
+  
+          <k-button icon="search" title="Search" :on_click="get_constrained_paths">
+          </k-button>
+        </k-accordion-item>
+      <k-accordion>
+    </div>
   </k-toolbar-item>
 </template>
 
@@ -99,7 +112,6 @@ module.exports = {
     get_constrained_paths (){
       var self = this
       var metrics = {}
-
       for(var checked of self.checkedList)
       {
         metrics[checked] = self.metrics[checked]

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -80,8 +80,11 @@
             </div>
           </div>
           <k-input :value.sync="metrics.ownership"></k-input>
+          <div class="text">
+            Minimum Flexible Hits:
+          </div>
           <k-slider :max = 6
-          :action="function (val) {maximum_misses = parseInt(val)}"></k-slider>
+          :action="function (val) {minimum_flexible_hits = parseInt(val)}"></k-slider>
           <k-button icon="search" title="Search" :on_click="get_constrained_paths">
           </k-button>
         </k-accordion-item>
@@ -139,7 +142,7 @@ module.exports = {
                "destination": self.destination_constrained,
                "base_metrics": base_metrics,
                "flexible_metrics": flexible_metrics,
-               "maximum_misses": self.maximum_misses
+               "minimum_flexible_hits": self.minimum_flexible_hits
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v2/best-constrained-paths",
@@ -270,7 +273,7 @@ module.exports = {
         priority: false,
         ownership: false
       },
-      maximum_misses: 0
+      minimum_flexible_hits: 0
     }
   }
 }
@@ -282,4 +285,5 @@ module.exports = {
   .metric {width:100%; overflow: hidden;}
   .checkbox {width:10%; float: left;}
   .dropdown {width:90%; float: left;}
+  .text {font-size: 75%; float: left; margin-top: 1vh;}
 </style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -214,7 +214,7 @@ module.exports = {
       var base_metrics = {}
       var flexible_metrics = {}
       for(var checked of self.v4_checked_list) {
-        if (self.v4_is_flexible[checked]) {
+        if (self.v4_is_flexible[checked] == 'true') {
           flexible_metrics[checked] = self.v4_metrics[checked]
         } else {
           base_metrics[checked] = self.v4_metrics[checked]
@@ -230,7 +230,8 @@ module.exports = {
                "destination": self.destination,
                "base_metrics": base_metrics,
                "flexible_metrics": flexible_metrics,
-               "depth": self.depth
+               "depth": self.depth,
+               "isFlexible": self.v4_is_flexible
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v4",

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -14,6 +14,56 @@
         </k-button>
 
       </k-accordion-item>
+      <k-accordion-item title="Best Constrained Path">
+        <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+          :value.sync="source"></k-dropdown>
+        <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+          :value.sync ="destination"></k-dropdown>
+
+        <k-checkbox icon="circle-o" title="Bandwidth:"
+        :model.sync = "checkedList" :value = "'bandwidth'"></k-checkbox>
+
+        <k-slider icon="circle-o"
+        :action="function (val) {metrics.bandwidth = parseInt(val)}"></k-slider>
+
+        <k-checkbox icon="circle-o" title="Reliability:"
+        :model.sync = "checkedList" :value = "'reliability'"></k-checkbox>
+
+        <k-slider icon="circle-o"
+        :action="function (val) {metrics.reliability = parseInt(val)}"></k-slider>
+
+        <k-checkbox icon="circle-o" title="Delay:"
+        :model.sync = "checkedList" :value = "'delay'"></k-checkbox>
+
+        <k-slider icon="circle-o"
+        :action="function (val) {metrics.delay = parseInt(val)}"></k-slider>
+
+        <k-checkbox icon="circle-o" title="Utilization:"
+        :model.sync = "checkedList" :value = "'utilization'"></k-checkbox>
+
+        <k-slider icon="circle-o"
+        :action="function (val) {metrics.utilization = parseInt(val)}"></k-slider>
+
+        <k-checkbox icon="circle-o" title="Priority:"
+        :model.sync = "checkedList" :value = "'priority'"></k-checkbox>
+
+        <k-slider icon="circle-o"
+        :action="function (val) {metrics.priority = parseInt(val)}"></k-slider>
+
+        <k-checkbox icon="circle-o" title="Ownership:"
+        :model.sync = "checkedList" :value = "'ownership'"></k-checkbox>
+
+        <k-input icon="circle-o"
+        :value.sync="metrics.ownership"></k-input>
+
+        <k-slider icon="circle-o" :max = 6
+        :action="function (val) {flexible = parseInt(val)}"></k-slider>
+
+        <k-button icon="search" title="Search" :on_click="get_constrained_paths">
+        </k-button>
+
+      </k-accordion-item>
+
     <k-accordion>
   </k-toolbar-item>
 </template>
@@ -38,6 +88,39 @@ module.exports = {
         success: function(data) {
             if (data['paths'][0] !== undefined){
                 self.paths = data['paths'][0].hops;
+            } else {
+                self.paths = []
+            }
+          self.show();
+        }
+      });
+
+    },
+    get_constrained_paths (){
+      var self = this
+      var metrics = {}
+      var checked
+      for(checked of self.checkedList)
+      {
+        metrics[checked] = self.metrics[checked]
+      }
+
+      $.ajax({
+        async: true,
+        dataType: "json",
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify({"source": self.source,
+               "destination": self.destination,
+               "metrics": metrics,
+               "flexible": self.flexible,
+               "checks": self.checkedList
+               }),
+
+        url: this.$kytos_server_api + "kytos/pathfinder/v3",
+        success: function(data) {
+            if (data[0] !== undefined){
+                self.paths = data[0]['paths'][0];
             } else {
                 self.paths = []
             }
@@ -106,7 +189,17 @@ module.exports = {
       source: "",
       destination: "",
       desired_links: [],
-      undesired_links: []
+      undesired_links: [],
+      checkedList: [],
+      metrics:{
+        bandwidth: 1,
+        reliability: 2,
+        delay: 3,
+        utilization: 4,
+        priority: 5,
+        ownership: "yo"
+      },
+      flexible: 6
     }
   }
 }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -14,6 +14,69 @@
           <k-button icon="search" title="Search" :on_click="get_paths">
           </k-button>
         </k-accordion-item>
+
+        <k-accordion-item title="Best Constrained Path with Flexible Metrics">
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['bandwidth']" 
+              :action="function(val) {is_flexible.bandwidth = val}"></k-dropdown>
+            </div>
+            <k-slider icon="adjust" :action="function(val) {metrics.bandwidth = parseInt(val)}"></k-slider>
+          </div>
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['reliability']" 
+              :action="function(val) {is_flexible.reliability = val}"></k-dropdown>
+            </div>
+            <k-slider icon="adjust" :action="function(val) {metrics.reliability = parseInt(val)}"></k-slider>
+          </div>
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['delay']" 
+              :action="function(val) {is_flexible.delay = val}"></k-dropdown>
+            </div>
+            <k-slider icon="adjust" :action="function(val) {metrics.delay = parseInt(val)}"></k-slider>
+          </div>
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['utilization']" 
+              :action="function(val) {is_flexible.utilization = val}"></k-dropdown>
+            </div>
+            <k-slider icon="adjust" :action="function(val) {metrics.utilization = parseInt(val)}"></k-slider>
+          </div>
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['priority']" 
+              :action="function(val) {is_flexible.priority = val}"></k-dropdown>
+            </div>
+            <k-slider icon="adjust" :action="function(val) {metrics.priority = parseInt(val)}"></k-slider>
+          </div>
+          <div style="width:100%; overflow: hidden;">
+            <div style="width:10%; float: left;">
+              <k-checkbox :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
+            </div>
+            <div style="width:90%; float: left;">
+              <k-dropdown :options="metric_options['ownership']" 
+              :action="function(val) {is_flexible.ownership = val}"></k-dropdown>
+            </div>
+            <k-input :value.sync="metrics.ownership"></k-input>
+          </div>
+        </k-accordion-item>
   
         <k-accordion-item title="Best Constrained Path">
           <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
@@ -28,7 +91,7 @@
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Bandwidth" 
-                :model.sync = "checkedList" :value = "'bandwidth'"></k-checkbox>
+                :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
@@ -36,7 +99,7 @@
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Reliability"
-                :model.sync = "checkedList" :value = "'reliability'"></k-checkbox>
+                :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
@@ -44,7 +107,7 @@
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Delay"
-                :model.sync = "checkedList" :value = "'delay'"></k-checkbox>
+                :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
@@ -52,7 +115,7 @@
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Utilization"
-                :model.sync = "checkedList" :value = "'utilization'"></k-checkbox>
+                :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
@@ -60,12 +123,12 @@
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Priority"
-                :model.sync = "checkedList" :value = "'priority'"></k-checkbox>
+                :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
               </div>
           </div>
   
           <k-checkbox icon="adjust" title="Ownership:"
-          :model.sync = "checkedList" :value = "'ownership'"></k-checkbox>
+          :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
   
           <k-input 
           :value.sync="metrics.ownership"></k-input>
@@ -111,8 +174,8 @@ module.exports = {
     },
     get_constrained_paths (){
       var self = this
-      var metrics = {}
-      for(var checked of self.checkedList)
+      var base_metrics = {}
+      for(var checked of self.checked_list)
       {
         metrics[checked] = self.metrics[checked]
       }
@@ -124,7 +187,7 @@ module.exports = {
         contentType: "application/json",
         data: JSON.stringify({"source": self.source,
                "destination": self.destination,
-               "base_metrics": metrics,
+               "base_metrics": base_metrics,
                "depth": self.depth
                }),
 
@@ -138,7 +201,22 @@ module.exports = {
           self.show();
         }
       });
-
+    },
+    get_constrained_paths_flexible(){
+      var self = this
+      var base_metrics = {}
+      var flexible_metrics = {}
+      for(var checked of self.checked_list)
+      {
+        if (self.is_flexible[checked]) 
+        {
+          flexible_metrics[checked] = self.metrics[checked]
+        }
+        else
+        {
+          base_metrics[checked] = self.metrics[checked]
+        }
+      }
     },
     get_topology(){
       var self = this
@@ -168,6 +246,43 @@ module.exports = {
   },
 
   computed: {
+    metric_options(){
+      var metric_options = {}
+
+      var bandwidth_options = []
+      var reliability_options = []
+      var delay_options = []
+      var utilization_options = []
+      var priority_options = []
+      var ownership_options = []
+
+      bandwidth_options.push({value: 'false', description: 'Bandwidth', selected: 'true'});
+      bandwidth_options.push({value: 'true', description: 'Bandwidth (Flexible)'});
+      
+      reliability_options.push({value: 'false', description: 'Reliability', selected: 'true'});
+      reliability_options.push({value: 'true', description: 'Reliability (Flexible)'});
+
+      delay_options.push({value: 'false', description: 'Delay', selected: 'true'});
+      delay_options.push({value: 'true', description: 'Delay (Flexible)'});
+
+      utilization_options.push({value: 'false', description: 'Utilization', selected: 'true'});
+      utilization_options.push({value: 'true', description: 'Utilization (Flexible)'});
+
+      priority_options.push({value: 'false', description: 'Priority', selected: 'true'});
+      priority_options.push({value: 'true', description: 'Priority (Flexible)'});
+
+      ownership_options.push({value: 'false', description: 'Ownership', selected: 'true'});
+      ownership_options.push({value: 'true', description: 'Ownership (Flexible)'});
+
+      metric_options["bandwidth"] = bandwidth_options
+      metric_options["reliability"] = reliability_options
+      metric_options["delay"] = delay_options
+      metric_options["utilization"] = utilization_options
+      metric_options["priority"] = priority_options
+      metric_options["ownership"] = ownership_options
+
+      return metric_options;
+    },
     get_interfaces(){
       var interfaces = []
       $.each(this.switches, function(key, value){
@@ -201,7 +316,7 @@ module.exports = {
       destination: "",
       desired_links: [],
       undesired_links: [],
-      checkedList: [],
+      checked_list: [],
       metrics:{
         bandwidth: 0,
         reliability: 0,
@@ -209,6 +324,14 @@ module.exports = {
         utilization: 0,
         priority: 0,
         ownership: ""
+      },
+      is_flexible:{
+        bandwidth: false,
+        reliability: false,
+        delay: false,
+        utilization: false,
+        priority: false,
+        ownership: false
       },
       depth: 0
     }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,6 +1,6 @@
 <template>
   <k-toolbar-item icon="compass" tooltip="Napp Pathfinder">
-    <div style="overflow-y: auto; height:550px;">
+    <div class="scroll">
       <k-accordion>
         <k-accordion-item title="Best Path">
          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
@@ -20,61 +20,61 @@
             :value.sync="source_constrained"></k-dropdown>
            <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
             :value.sync ="destination_constrained"></k-dropdown>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['bandwidth']" 
                :value.sync="is_flexible.bandwidth"></k-dropdown>
             </div>
             <k-slider icon="adjust" :action="function(val) {metrics.bandwidth = parseInt(val)}"></k-slider>
           </div>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['reliability']" 
               :value.sync="is_flexible.reliability"></k-dropdown>
             </div>
             <k-slider icon="adjust" :action="function(val) {metrics.reliability = parseInt(val)}"></k-slider>
           </div>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['delay']" 
               :value.sync="is_flexible.delay"></k-dropdown>
             </div>
             <k-slider icon="adjust" :action="function(val) {metrics.delay = parseInt(val)}"></k-slider>
           </div>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['utilization']" 
               :value.sync="is_flexible.utilization"></k-dropdown>
             </div>
             <k-slider icon="adjust" :action="function(val) {metrics.utilization = parseInt(val)}"></k-slider>
           </div>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['priority']" 
               :value.sync="is_flexible.priority"></k-dropdown>
             </div>
             <k-slider icon="adjust" :action="function(val) {metrics.priority = parseInt(val)}"></k-slider>
           </div>
-          <div style="width:100%; overflow: hidden;">
-            <div style="width:10%; float: left;">
+          <div class="metric">
+            <div class="checkbox">
               <k-checkbox :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
             </div>
-            <div style="width:90%; float: left;">
+            <div class="dropdown">
               <k-dropdown :options="metric_options['ownership']" 
               :value.sync="is_flexible.ownership"></k-dropdown>
             </div>
@@ -277,7 +277,9 @@ module.exports = {
 </script>
 
 <style type="text/css">
-body{
-    overflow-y:hidden;
-}
+  body {overflow-y:hidden;}
+  .scroll {overflow-y: auto; height:calc(100vh - 60px);}
+  .metric {width:100%; overflow: hidden;}
+  .checkbox {width:10%; float: left;}
+  .dropdown {width:90%; float: left;}
 </style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -23,40 +23,40 @@
         <k-checkbox icon="circle-o" title="Bandwidth:"
         :model.sync = "checkedList" :value = "'bandwidth'"></k-checkbox>
 
-        <k-slider icon="circle-o"
+        <k-slider 
         :action="function (val) {metrics.bandwidth = parseInt(val)}"></k-slider>
 
         <k-checkbox icon="circle-o" title="Reliability:"
         :model.sync = "checkedList" :value = "'reliability'"></k-checkbox>
 
-        <k-slider icon="circle-o"
+        <k-slider
         :action="function (val) {metrics.reliability = parseInt(val)}"></k-slider>
 
         <k-checkbox icon="circle-o" title="Delay:"
         :model.sync = "checkedList" :value = "'delay'"></k-checkbox>
 
-        <k-slider icon="circle-o"
+        <k-slider 
         :action="function (val) {metrics.delay = parseInt(val)}"></k-slider>
 
         <k-checkbox icon="circle-o" title="Utilization:"
         :model.sync = "checkedList" :value = "'utilization'"></k-checkbox>
 
-        <k-slider icon="circle-o"
+        <k-slider 
         :action="function (val) {metrics.utilization = parseInt(val)}"></k-slider>
 
         <k-checkbox icon="circle-o" title="Priority:"
         :model.sync = "checkedList" :value = "'priority'"></k-checkbox>
 
-        <k-slider icon="circle-o"
+        <k-slider
         :action="function (val) {metrics.priority = parseInt(val)}"></k-slider>
 
         <k-checkbox icon="circle-o" title="Ownership:"
         :model.sync = "checkedList" :value = "'ownership'"></k-checkbox>
 
-        <k-input icon="circle-o"
+        <k-input 
         :value.sync="metrics.ownership"></k-input>
 
-        <k-slider icon="circle-o" :max = 6
+        <k-slider :max = 6
         :action="function (val) {flexible = parseInt(val)}"></k-slider>
 
         <k-button icon="search" title="Search" :on_click="get_constrained_paths">
@@ -198,7 +198,7 @@ module.exports = {
         priority: 0,
         ownership: ""
       },
-      flexible: 6
+      flexible: 0
     }
   }
 }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -191,12 +191,12 @@ module.exports = {
       undesired_links: [],
       checkedList: [],
       metrics:{
-        bandwidth: 1,
-        reliability: 2,
-        delay: 3,
-        utilization: 4,
-        priority: 5,
-        ownership: "yo"
+        bandwidth: 0,
+        reliability: 0,
+        delay: 0,
+        utilization: 0,
+        priority: 0,
+        ownership: ""
       },
       flexible: 6
     }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -16,66 +16,77 @@
         </k-accordion-item>
 
         <k-accordion-item title="Best Constrained Path with Flexible Metrics">
+          <k-dropdown icon="circle-o" title="Source:" :options="get_interfaces"
+            :value.sync="source"></k-dropdown>
+          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
+            :value.sync ="destination"></k-dropdown>
+
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'bandwidth'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['bandwidth']" 
-              :action="function(val) {is_flexible.bandwidth = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.bandwidth"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {metrics.bandwidth = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {v4_metrics.bandwidth = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'reliability'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['reliability']" 
-              :action="function(val) {is_flexible.reliability = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.reliability"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {metrics.reliability = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {v4_metrics.reliability = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'delay'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['delay']" 
-              :action="function(val) {is_flexible.delay = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.delay"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {metrics.delay = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {v4_metrics.delay = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'utilization'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['utilization']" 
-              :action="function(val) {is_flexible.utilization = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.utilization"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {metrics.utilization = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {v4_metrics.utilization = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'priority'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['priority']" 
-              :action="function(val) {is_flexible.priority = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.priority"></k-dropdown>
             </div>
-            <k-slider icon="adjust" :action="function(val) {metrics.priority = parseInt(val)}"></k-slider>
+            <k-slider icon="adjust" :action="function(val) {v4_metrics.priority = parseInt(val)}"></k-slider>
           </div>
           <div style="width:100%; overflow: hidden;">
             <div style="width:10%; float: left;">
-              <k-checkbox :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
+              <k-checkbox :model.sync = "v4_checked_list" :value = "'ownership'"></k-checkbox>
             </div>
             <div style="width:90%; float: left;">
               <k-dropdown :options="metric_options['ownership']" 
-              :action="function(val) {is_flexible.ownership = val}"></k-dropdown>
+              :value.sync="v4_is_flexible.ownership"></k-dropdown>
             </div>
-            <k-input :value.sync="metrics.ownership"></k-input>
           </div>
+          <k-input :value.sync="v4_metrics.ownership"></k-input>
+
+          <k-slider :max = 6
+          :action="function (val) {depth = parseInt(val)}"></k-slider>
+  
+          <k-button icon="search" title="Search" :on_click="get_constrained_paths_v4">
+          </k-button>
         </k-accordion-item>
   
         <k-accordion-item title="Best Constrained Path">
@@ -87,56 +98,53 @@
           <div style="width: 100%; overflow: hidden;">
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
-                :action="function (val) {metrics.bandwidth = parseInt(val)}"></k-slider>
+                :action="function (val) {v3_metrics.bandwidth = parseInt(val)}"></k-slider>
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Bandwidth" 
-                :model.sync = "checked_list" :value = "'bandwidth'"></k-checkbox>
+                :model.sync = "v3_checked_list" :value = "'bandwidth'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
-                :action="function (val) {metrics.reliability = parseInt(val)}"></k-slider>
+                :action="function (val) {v3_metrics.reliability = parseInt(val)}"></k-slider>
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Reliability"
-                :model.sync = "checked_list" :value = "'reliability'"></k-checkbox>
+                :model.sync = "v3_checked_list" :value = "'reliability'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
-                :action="function (val) {metrics.delay = parseInt(val)}"></k-slider>
+                :action="function (val) {v3_metrics.delay = parseInt(val)}"></k-slider>
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Delay"
-                :model.sync = "checked_list" :value = "'delay'"></k-checkbox>
+                :model.sync = "v3_checked_list" :value = "'delay'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
-                :action="function (val) {metrics.utilization = parseInt(val)}"></k-slider>
+                :action="function (val) {v3_metrics.utilization = parseInt(val)}"></k-slider>
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Utilization"
-                :model.sync = "checked_list" :value = "'utilization'"></k-checkbox>
+                :model.sync = "v3_checked_list" :value = "'utilization'"></k-checkbox>
               </div>
               <div style="width:50%; float: left;"> 
                 <k-slider icon="adjust"
-                :action="function (val) {metrics.priority = parseInt(val)}"></k-slider>
+                :action="function (val) {v3_metrics.priority = parseInt(val)}"></k-slider>
               </div>
               <div style="margin-left: 1em;"> 
                 <k-checkbox title="Priority"
-                :model.sync = "checked_list" :value = "'priority'"></k-checkbox>
+                :model.sync = "v3_checked_list" :value = "'priority'"></k-checkbox>
               </div>
           </div>
   
           <k-checkbox icon="adjust" title="Ownership:"
-          :model.sync = "checked_list" :value = "'ownership'"></k-checkbox>
+          :model.sync = "v3_checked_list" :value = "'ownership'"></k-checkbox>
   
           <k-input 
-          :value.sync="metrics.ownership"></k-input>
+          :value.sync="v3_metrics.ownership"></k-input>
   
-          <k-slider :max = 6
-          :action="function (val) {depth = parseInt(val)}"></k-slider>
-  
-          <k-button icon="search" title="Search" :on_click="get_constrained_paths">
+          <k-button icon="search" title="Search" :on_click="get_constrained_paths_v3">
           </k-button>
         </k-accordion-item>
       <k-accordion>
@@ -172,12 +180,12 @@ module.exports = {
       });
 
     },
-    get_constrained_paths (){
+    get_constrained_paths_v3 (){
       var self = this
-      var base_metrics = {}
-      for(var checked of self.checked_list)
+      var metrics = {}
+      for(var checked of self.v3_checked_list)
       {
-        metrics[checked] = self.metrics[checked]
+        metrics[checked] = self.v3_metrics[checked]
       }
 
       $.ajax({
@@ -187,8 +195,7 @@ module.exports = {
         contentType: "application/json",
         data: JSON.stringify({"source": self.source,
                "destination": self.destination,
-               "base_metrics": base_metrics,
-               "depth": self.depth
+               "base_metrics": metrics
                }),
 
         url: this.$kytos_server_api + "kytos/pathfinder/v3",
@@ -202,21 +209,40 @@ module.exports = {
         }
       });
     },
-    get_constrained_paths_flexible(){
+    get_constrained_paths_v4(){
       var self = this
       var base_metrics = {}
       var flexible_metrics = {}
-      for(var checked of self.checked_list)
-      {
-        if (self.is_flexible[checked]) 
-        {
-          flexible_metrics[checked] = self.metrics[checked]
-        }
-        else
-        {
-          base_metrics[checked] = self.metrics[checked]
+      for(var checked of self.v4_checked_list) {
+        if (self.v4_is_flexible[checked]) {
+          flexible_metrics[checked] = self.v4_metrics[checked]
+        } else {
+          base_metrics[checked] = self.v4_metrics[checked]
         }
       }
+      
+      $.ajax({
+        async: true,
+        dataType: "json",
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify({"source": self.source,
+               "destination": self.destination,
+               "base_metrics": base_metrics,
+               "flexible_metrics": flexible_metrics,
+               "depth": self.depth
+               }),
+
+        url: this.$kytos_server_api + "kytos/pathfinder/v4",
+        success: function(data) {
+            if (data[0] !== undefined){
+                self.paths = data[0]['paths'][0];
+            } else {
+                self.paths = []
+            }
+          self.show();
+        }
+      });
     },
     get_topology(){
       var self = this
@@ -316,8 +342,8 @@ module.exports = {
       destination: "",
       desired_links: [],
       undesired_links: [],
-      checked_list: [],
-      metrics:{
+      v3_checked_list: [],
+      v3_metrics:{
         bandwidth: 0,
         reliability: 0,
         delay: 0,
@@ -325,7 +351,16 @@ module.exports = {
         priority: 0,
         ownership: ""
       },
-      is_flexible:{
+      v4_checked_list: [],
+      v4_metrics:{
+        bandwidth: 0,
+        reliability: 0,
+        delay: 0,
+        utilization: 0,
+        priority: 0,
+        ownership: ""
+      },
+      v4_is_flexible:{
         bandwidth: false,
         reliability: false,
         delay: false,


### PR DESCRIPTION
This helps resolve #22

Demo of current iteration:
![Peek 2020-07-28 21-17](https://user-images.githubusercontent.com/26232289/88745440-116d0880-d118-11ea-972b-fc1a649350d5.gif)

This updates the UI to support searches for multiple shortest constrained flexible paths. This change affects only the interface - the logic will be the subject of a separate pull request.

Elements Added:
- A dropdown menu for "_Best Constrained Paths_"
   - Options to filter out paths with edges that fail to meet the following requirements:
      - Bandwidth less than minimum
      - Reliability less than minimum
      - Delay more than maximum
      - Utilization more than maximum
      - Priority less than minimum
      - Owner different than the requested owner
   - Option to set the flexibility of the filtering.
      - 0 (none): include only edges that hit all requirements.
      - 0 < n < 6 (partial): include only edges that have at most n misses (n is an integer). 
      - 6 (full): allow all edges regardless of misses.
- A scrollbar in case the elements overflow.

Screenshots:
Open
![Screenshot from 2020-06-10 16-54-00](https://user-images.githubusercontent.com/26232289/84318005-bd906b00-ab3b-11ea-9f1d-daab4719287c.png)
Closed
![Screenshot from 2020-06-10 16-55-37](https://user-images.githubusercontent.com/26232289/84317987-b701f380-ab3b-11ea-8a8d-8891a6dcb0c0.png)

