### PR TITLE
Change keys.extend(..) to keys.append(..)

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -46,7 +46,7 @@ class KytosGraph:
             if link.is_active():
                 self.graph.add_edge(link.endpoint_a.id, link.endpoint_b.id)
                 for key, value in link.metadata.items():
-                    keys.extend(key)
+                    keys.append(key)
                     endpoint_a = link.endpoint_a.id
                     endpoint_b = link.endpoint_b.id
                     self.graph[endpoint_a][endpoint_b][key] = value

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -58,7 +58,8 @@ class TestGraph(TestCase):
         keys = []
         all_metadata = [link.metadata for link in topology.links.values()]
         for metadata in all_metadata:
-            keys.extend(key for key in metadata.keys())
+            for key in metadata.keys():
+                keys.append(key)
         mock_set_default_metadata.assert_called_with(keys)
 
     def test_remove_switch_hops(self):

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -58,8 +58,7 @@ class TestGraph(TestCase):
         keys = []
         all_metadata = [link.metadata for link in topology.links.values()]
         for metadata in all_metadata:
-            for key in metadata.keys():
-                keys.append(key)
+            keys.extend(key for key in metadata.keys())
         mock_set_default_metadata.assert_called_with(keys)
 
     def test_remove_switch_hops(self):


### PR DESCRIPTION
@hdiogenes 

This fixes #64. This also updates test_update_links so its keys setup implementation matches update_links.

The unit test for update_links did not catch this error because it filled up the array differently:

```python
test = ["apple", "banana", "grape"]
test2 = []

test3 = []

# update_links implementation
for t in test:
    test2.extend(t)

# test_update_links implementation
test3.extend(t for t in test)
```

test2 is `['a', 'p', 'p', 'l', 'e', 'b', 'a', 'n', 'a', 'n', 'a', 'g', 'r', 'a', 'p', 'e']`
test3 is `['apple', 'banana', 'grape']`, as intended.

In addition, it uses a helper method `get_link_mock` from `kytos.lib.helpers` to set up a topology, and this topology uses single-letter attributes for each of its links:

```python
def get_link_mock(endpoint_a, endpoint_b):
    """Return a link mock."""
    link = create_autospec(Link)
    link.endpoint_a = endpoint_a
    link.endpoint_b = endpoint_b
    link.metadata = {"A": 0}
    return link
```

And #64 does not occur if `update_links` works with links that have only single-letter attributes. Namely, this code would detect a difference in metadata names and throw an `AssertionError` if it was working with multi-letter attributes:

```python
        for metadata in all_metadata:
            keys.extend(key for key in metadata.keys())
        # This is where the assertion would fail
        mock_set_default_metadata.assert_called_with(keys)
```

But each link has only one attribute and that attribute is a single letter. So the test sees the equal lists and incorrectly assumes that its method under test is working as expected.