### PR TITLE
update requirements to solve conflicts: six, click, pluggy and flask

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@
 -e .
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 astroid==2.2.5            # via pylint
-click==7.0                # via pip-tools
+click==7.1.1              # via pip-tools
 coverage==5.0.3
 docopt==0.6.2             # via yala
 filelock==3.0.10          # via tox
@@ -16,13 +16,13 @@ isort==4.3.15             # via pylint, yala
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
 pip-tools==3.4.0
-pluggy==0.9.0             # via tox
+pluggy                    # via tox
 py==1.8.0                 # via tox
 pycodestyle==2.5.0        # via yala
 pydocstyle==3.0.0         # via yala
 pylint==2.3.1             # via yala
 pytest==5.4.1             # via pytest
-six==1.12.0               # via astroid, pip-tools, pydocstyle, tox
+six==1.15.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 toml==0.10.0              # via tox
 tox==3.7.0
@@ -31,4 +31,4 @@ virtualenv==16.4.3        # via tox
 wrapt==1.11.1             # via astroid
 yala==1.7.0
 networkx==2.2
-flask==1.0.2
+flask==1.1.2


### PR DESCRIPTION
Fix #69 

### :bookmark_tabs: Description of the Change

This PR updates the version of some dev requirements due to conflicts (especially with Kytos 2020.2):
- flask==1.0.2 => flask==1.1.2
- six==1.12.0 => six==1.15.0
- click==7.0 => click==7.1.1
- pluggy==0.9.0 => pluggy

### :computer: Verification Process

To test this fix, I've run the unit tests using tox:
- created a docker container based on the image python:3.6
- install tox with `pip install tox`
- clone and run the unit tests for pathfinder:
```
============================================================ test session starts =============================================================
platform linux -- Python 3.6.13, pytest-5.4.1, py-1.8.0, pluggy-0.13.1
cachedir: .tox/py36/.pytest_cache
rootdir: /pathfinder, inifile: setup.cfg
collected 10 items

tests/unit/test_graph.py ......                                                                                                        [ 60%]
tests/unit/test_main.py ....                                                                                                           [100%]

============================================================== warnings summary ==============================================================
tests/unit/test_main.py::TestMain::test_filter_paths
tests/unit/test_main.py::TestMain::test_shortest_path
tests/unit/test_main.py::TestMain::test_update_topology_failure_case
tests/unit/test_main.py::TestMain::test_update_topology_success_case
  /pathfinder/.tox/py36/src/kytos/kytos/core/config.py:167: UserWarning: Unknown arguments: ['tests/unit']
    warnings.warn(f"Unknown arguments: {unknown}")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================= 10 passed, 4 warnings in 6.94s =======================================================
Name          Stmts   Miss  Cover
---------------------------------
__init__.py       0      0   100%
graph.py         51      7    86%
main.py          55      4    93%
settings.py       0      0   100%
---------------------------------
TOTAL           106     11    90%
lint installed: astroid==2.2.5,attrs==20.3.0,backcall==0.1.0,click==7.1.1,coverage==5.0.3,decorator==4.4.2,docopt==0.6.2,docutils==0.16,filelock==3.0.10,Flask==1.1.2,Flask-Cors==3.0.8,Flask-SocketIO==4.2.1,importlib-metadata==4.0.1,ipython==7.13.0,ipython-genutils==0.2.0,isort==4.3.15,itsdangerous==1.1.0,janus==0.4.0,jedi==0.16.0,Jinja2==2.11.1,-e git+https://github.com/kytos/kytos.git@4633321b3dcc4d1ee4c01cdaa19bbb1833a47fdf#egg=kytos,-e git+https://github.com/kytos/pathfinder@d7500f52a5a4354c23064866411168a8da026755#egg=kytos_pathfinder,lazy-object-proxy==1.3.1,lockfile==0.12.2,MarkupSafe==1.1.1,mccabe==0.6.1,more-itertools==8.7.0,networkx==2.2,packaging==20.9,parso==0.6.2,pathtools==0.1.2,pexpect==4.8.0,pickleshare==0.7.5,pip-tools==3.4.0,pluggy==0.13.1,prompt-toolkit==3.0.5,ptyprocess==0.6.0,py==1.8.0,pycodestyle==2.5.0,pydocstyle==3.0.0,Pygments==2.7.1,PyJWT==1.7.1,pylint==2.3.1,pyparsing==2.4.7,pytest==5.4.1,python-daemon==2.2.4,python-engineio==3.12.1,-e git+https://github.com/kytos/pathfinder@d7500f52a5a4354c23064866411168a8da026755#egg=python_openflow,python-socketio==4.5.1,six==1.15.0,snowballstemmer==1.2.1,toml==0.10.0,tox==3.7.0,traitlets==4.3.3,typed-ast==1.3.1,typing-extensions==3.7.4.3,virtualenv==16.4.3,watchdog==0.10.2,wcwidth==0.1.9,Werkzeug==1.0.1,wrapt==1.11.1,yala==1.7.0,zipp==3.4.1
lint run-test-pre: PYTHONHASHSEED='1388597868'
lint run-test: commands[0] | python setup.py lint
running lint
Yala is running. It may take several seconds...
:) No issues found.
No linter error found.
__________________________________________________________________ summary ___________________________________________________________________
  coverage: commands succeeded
  lint: commands succeeded
  congratulations :)
```

### :page_facing_up: Release Notes

- Update development dependencies to match Kytos 2020.2 release: six, click, pluggy and flask